### PR TITLE
Add inlcude guards to libtrac.h

### DIFF
--- a/src/libtrac.h
+++ b/src/libtrac.h
@@ -22,6 +22,9 @@
   MPTRAC library declarations.
 */
 
+#ifndef LIBTRAC_H
+#define LIBTRAC_H
+
 /* ------------------------------------------------------------
    Includes...
    ------------------------------------------------------------ */
@@ -1623,3 +1626,5 @@ void write_station(
   ctl_t * ctl,
   atm_t * atm,
   double t);
+
+#endif /* LIBTRAC_H */


### PR DESCRIPTION
libtrac.h was missing include guards which makes it
impossbible to use the header in multiple files of the same
project.
We added the include guards.