### PR TITLE
Move multiGPU implementation inside modules

### DIFF
--- a/src/libtrac.c
+++ b/src/libtrac.c
@@ -1017,13 +1017,14 @@ void get_met(
 
     /* Update GPU... */
 #ifdef _OPENACC
-  for(int device_num = 0; device_num < num_devices; device_num++) {
+#pragma omp parallel num_threads(num_devices)
+{
+    int device_num = omp_get_thread_num();
     acc_set_device_num(device_num, acc_device_nvidia);
-
     met_t *met0up = *met0;
     met_t *met1up = *met1;
 #pragma acc update device(met0up[:1],met1up[:1])
-  }
+}
 #endif
 
     /* Caching... */
@@ -1053,11 +1054,14 @@ void get_met(
     /* Update GPU... */
 #ifdef _OPENACC
   printf("**===--------------> NUM OF DEVICES IS %d.\n", num_devices);
-  for(int device_num = 0; device_num < num_devices; device_num++) {
+
+#pragma omp parallel num_threads(num_devices)
+{
+    int device_num = omp_get_thread_num();
     acc_set_device_num(device_num, acc_device_nvidia);
     met_t *met1up = *met1;
 #pragma acc update device(met1up[:1])
-  }
+}
 #endif
 
     /* Caching... */
@@ -1087,11 +1091,14 @@ void get_met(
     /* Update GPU... */
 #ifdef _OPENACC
   printf("**===--------------> NUM OF DEVICES IS %d.\n", num_devices);
-  for(int device_num = 0; device_num < num_devices; device_num++) {
+
+#pragma omp parallel num_threads(num_devices)
+{
+    int device_num = omp_get_thread_num();
     acc_set_device_num(device_num, acc_device_nvidia);
     met_t *met0up = *met0;
 #pragma acc update device(met0up[:1])
-  }
+}
 #endif
 
     /* Caching... */

--- a/src/trac.c
+++ b/src/trac.c
@@ -530,7 +530,7 @@ for(int device_num = 0; device_num < num_devices; device_num++) {
 void generate_random_nums(randoms_t *random_num, ulong count) {
 
 #ifdef _OPENACC
-#pragma omp parallel num_threads(num_devices)
+#pragma omp parallel num_threads(num_devices) firstprivate(random_num)
 {
     int dev_id = omp_get_thread_num();
     acc_set_device_num(dev_id, acc_device_nvidia);


### PR DESCRIPTION
These patches move the multi-GPU load distribution inside each module.
The global random_num container's need to be a "firstprivate" inside the random number generator module