### PR TITLE
Build zlib with -fPIC flag

### DIFF
--- a/libs/build.sh
+++ b/libs/build.sh
@@ -160,6 +160,7 @@ fi
 if [ $ifBuildAll = true ] || [ $ifBuildZLIB = true ] ; then 
     cd $strLibsDir	
     printf "Starting to compile ZLIB\n"
+    export CFLAGS="-fPIC"
     strTarget=$strFileZLIB
     cp $strTarget.tar.bz2 $strBuildDir/src && cd $strBuildDir/src && tar xvjf $strTarget.tar.bz2
     cd $strBuildDir/src/$strTarget \


### PR DESCRIPTION
On some systems, e.g. SuperMUC-NG, the zlib binary cannot locate some symbols defined as a position-independent code (PIC). 

To resolve this build the entire zlib to use PIC.