### PR TITLE
change slmet-mnt to slmet_mnt

### DIFF
--- a/projects/web_runner/app.py
+++ b/projects/web_runner/app.py
@@ -58,25 +58,25 @@ app = Flask(__name__)
 
 # Meteo options...
 MET_OPTIONS = {
-    'aifs_6h': dict(METBASE='/mnt/slmet-mnt/met_data/ecmwf/open_data/data/aifs-single_YYYY_MM_DD/aifs-single',
+    'aifs_6h': dict(METBASE='/mnt/slmet_mnt/met_data/ecmwf/open_data/data/aifs-single_YYYY_MM_DD/aifs-single',
                     DT_MET=21600, MET_VERT_COORD=0, MET_PRESS_LEVEL_DEF=-1, MET_NAME='ECMWF AIFS'),
-    'ifs_6h': dict(METBASE='/mnt/slmet-mnt/met_data/ecmwf/open_data/data/ifs_YYYY_MM_DD/ifs',
+    'ifs_6h': dict(METBASE='/mnt/slmet_mnt/met_data/ecmwf/open_data/data/ifs_YYYY_MM_DD/ifs',
                    DT_MET=21600, MET_VERT_COORD=0, MET_PRESS_LEVEL_DEF=-1, MET_NAME='ECMWF IFS'),
-    'gfs_3h': dict(METBASE='/mnt/slmet-mnt/met_data/ncep/gfs/data_YYYY_MM_DD/gfs',
+    'gfs_3h': dict(METBASE='/mnt/slmet_mnt/met_data/ncep/gfs/data_YYYY_MM_DD/gfs',
                    DT_MET=10800, MET_VERT_COORD=0, MET_PRESS_LEVEL_DEF=-1, MET_NAME='NCEP GFS'),
-    'era5low_6h': dict(METBASE='/mnt/slmet-mnt/met_data/ecmwf/era5.1/resolution_1x1/nc/YYYY/MM/era5',
+    'era5low_6h': dict(METBASE='/mnt/slmet_mnt/met_data/ecmwf/era5.1/resolution_1x1/nc/YYYY/MM/era5',
                        DT_MET=21600, MET_VERT_COORD=1, MET_PRESS_LEVEL_DEF=6, MET_NAME='ERA5'),
-    'erai_6h': dict(METBASE='/mnt/slmet-mnt/met_data/ecmwf/era_interim/pressure_0.75deg_v2/nc/YYYY/ei',
+    'erai_6h': dict(METBASE='/mnt/slmet_mnt/met_data/ecmwf/era_interim/pressure_0.75deg_v2/nc/YYYY/ei',
                     DT_MET=21600, MET_VERT_COORD=0, MET_PRESS_LEVEL_DEF=-1, MET_NAME='ERA-Interim'),
-    'jra3q_6h': dict(METBASE='/mnt/slmet-mnt/met_data/jma/jra3q/nc/YYYY/jra3q',
+    'jra3q_6h': dict(METBASE='/mnt/slmet_mnt/met_data/jma/jra3q/nc/YYYY/jra3q',
                      DT_MET=21600, MET_VERT_COORD=2, MET_PRESS_LEVEL_DEF=6, MET_NAME='JRA-3Q'),
-    'jra55_6h': dict(METBASE='/mnt/slmet-mnt/met_data/jma/jra55/nc/YYYY/jra55',
+    'jra55_6h': dict(METBASE='/mnt/slmet_mnt/met_data/jma/jra55/nc/YYYY/jra55',
                      DT_MET=21600, MET_VERT_COORD=4, MET_PRESS_LEVEL_DEF=6, MET_NAME='JRA-55'),
-    'merra2_3h': dict(METBASE='/mnt/slmet-mnt/met_data/nasa/merra-2/hybrid/YYYY/merra2',
+    'merra2_3h': dict(METBASE='/mnt/slmet_mnt/met_data/nasa/merra-2/hybrid/YYYY/merra2',
                       DT_MET=10800, MET_VERT_COORD=1, MET_PRESS_LEVEL_DEF=6, MET_NAME='MERRA-2'),
-    'ncep_6h': dict(METBASE='/mnt/slmet-mnt/met_data/ncep/reanalysis/nc/YYYY/ncep',
+    'ncep_6h': dict(METBASE='/mnt/slmet_mnt/met_data/ncep/reanalysis/nc/YYYY/ncep',
                     DT_MET=21600, MET_VERT_COORD=0, MET_PRESS_LEVEL_DEF=-1, MET_NAME='NCEP-NCAR Reanalysis 1'),
-    'ncep2_6h': dict(METBASE='/mnt/slmet-mnt/met_data/ncep/reanalysis2/nc/YYYY/ncep2',
+    'ncep2_6h': dict(METBASE='/mnt/slmet_mnt/met_data/ncep/reanalysis2/nc/YYYY/ncep2',
                      DT_MET=21600, MET_VERT_COORD=0, MET_PRESS_LEVEL_DEF=-1, MET_NAME='NCEP-DOE Reanalysis 2')
 }
 
@@ -237,11 +237,11 @@ def run():
         start_dt = datetime.strptime(f['start_time'], "%Y-%m-%d %H:%M")
         start_time, stop_time = map(seconds_since_2000, (f['start_time'], f['stop_time']))
         if met_source == 'aifs_6h':
-            METBASE = f"/mnt/slmet-mnt/met_data/ecmwf/open_data/data/aifs-single_{start_dt.strftime('%Y_%m_%d')}/aifs-single"
+            METBASE = f"/mnt/slmet_mnt/met_data/ecmwf/open_data/data/aifs-single_{start_dt.strftime('%Y_%m_%d')}/aifs-single"
         if met_source == 'ifs_6h':
-            METBASE = f"/mnt/slmet-mnt/met_data/ecmwf/open_data/data/ifs_{start_dt.strftime('%Y_%m_%d')}/ifs"
+            METBASE = f"/mnt/slmet_mnt/met_data/ecmwf/open_data/data/ifs_{start_dt.strftime('%Y_%m_%d')}/ifs"
         if met_source == 'gfs_3h':
-            METBASE = f"/mnt/slmet-mnt/met_data/ncep/gfs/data_{start_dt.strftime('%Y_%m_%d')}/gfs"
+            METBASE = f"/mnt/slmet_mnt/met_data/ncep/gfs/data_{start_dt.strftime('%Y_%m_%d')}/gfs"
         mlon, mlat, mz = to_f('mlon'), to_f('mlat'), to_f('mz')
         ulon, ulat, uz = to_f('ulon'), to_f('ulat'), to_f('uz')
         slon, slat, sz = to_f('slon'), to_f('slat'), to_f('sz')


### PR DESCRIPTION
This PR updates the NFS storage mount path in the MPTRAC web runner from:
```
/mnt/slmet-mnt
```
to:
```
/mnt/slmet_mnt
```
and adjusts the application code accordingly.
The change was necessary to ensure that the storage mounts correctly using a dedicated systemd mount unit and that the MPTRAC web service reliably starts after system reboots or JSC Cloud maintenance.

## Reasons:
The previous mount path (`/mnt/slmet-mnt`) caused issues when creating a persistent systemd mount unit. Systemd interprets dashes (`-`) in mount-unit filenames as escape characters for path translation. This leads to ambiguous or inconsistent mappings when systemd generates mount units automatically, and it can interfere with predictable behavior during boot.

To avoid this ambiguity and follow systemd best practices, the mount point was renamed to:
```
/mnt/slmet_mnt
```
Underscores map cleanly and predictably to mount units:
```
/mnt/slmet_mnt  ⇨  mnt-slmet_mnt.mount
```
This makes systemd’s path-to-unit resolution reliable and prevents conflicts with the NetworkManager and fstab-generated units.